### PR TITLE
COOP Realiza Chequeo Interactivo Cuando el Parser Guarda un Metodo

### DIFF
--- a/Cuis-University-COOP.st
+++ b/Cuis-University-COOP.st
@@ -1,20 +1,20 @@
 !classDefinition: #COOP category: #'Cuis-University-COOP'!
 Object subclass: #COOP
-	instanceVariableNames: ''
+	instanceVariableNames: 'rules'
 	classVariableNames: ''
 	poolDictionaries: ''
 	category: 'Cuis-University-COOP'!
 
 !COOP methodsFor: 'testing' stamp: 'GET 9/8/2019 15:03:11'!
-searchMessageToCollectionsOn: aStatement 
-	
+searchMessageToCollectionsOn: aStatement
+
 	| collectionSendedMessageRule |
 	collectionSendedMessageRule _ CollectionSendedMessageCheck new with:aStatement.
 	^ collectionSendedMessageRule analyze.! !
 
 !COOP methodsFor: 'testing' stamp: 'GET 9/8/2019 12:18:16'!
-wasSendedToCollection: aMethodNode 
-	
+wasSendedToCollection: aMethodNode
+
 	^  aMethodNode body statements anySatisfy: [:statement | self searchMessageToCollectionsOn: statement ] ! !
 
 
@@ -26,22 +26,22 @@ Object subclass: #COOPHelper
 	category: 'Cuis-University-COOP'!
 
 !COOPHelper methodsFor: 'error' stamp: 'GET 9/8/2019 12:50:43'!
-messageNotFound: aSelector in: aClass 
+messageNotFound: aSelector in: aClass
 
 	self error: 'the message with ', aSelector , 'was not found in ', aClass className .
 	! !
 
 
 !COOPHelper methodsFor: 'action' stamp: 'GET 9/8/2019 12:50:55'!
-search: aSelectorName in: aClass 
+search: aSelectorName in: aClass
 
-	^ aClass compiledMethodAt: aSelectorName ifPresent: [:compiledMethod | ^ compiledMethod ] ifAbsent: [ self messageNotFound: aSelectorName in: aClass ]. 
+	^ aClass compiledMethodAt: aSelectorName ifPresent: [:compiledMethod | ^ compiledMethod ] ifAbsent: [ self messageNotFound: aSelectorName in: aClass ].
  ! !
 
 
 !COOPHelper methodsFor: 'testing' stamp: 'GET 9/8/2019 18:59:15'!
-exist: selectors in: aClass 
-	
+exist: selectors in: aClass
+
 	^ selectors notEmpty and: [ aClass methodDict keys includesAnyOf:  selectors ].	! !
 
 
@@ -69,7 +69,7 @@ analyze
 	| parser |
 	parser _ ParseNodeEnumerator ofBlock: [:node | self addMessageNode: node].
 	statementNode accept: parser.
-		
+
 	self findCollectionSelectors.
 
 	 ^ COOPHelper new exist: selectors in: Collection .! !
@@ -77,9 +77,9 @@ analyze
 
 !CollectionSendedMessageCheck methodsFor: 'accessing' stamp: 'GET 9/8/2019 19:39:59'!
 findCollectionSelectors
-	
+
 	| messageParser |
-	messageParser _ ParseNodeEnumerator ofBlock: [:node | selectors add: node selector  key] select: [:node | node isMessageNode]. 
+	messageParser _ ParseNodeEnumerator ofBlock: [:node | selectors add: node selector  key] select: [:node | node isMessageNode].
 	allNodes do: [:node | node accept: messageParser ].
 	! !
 
@@ -88,3 +88,14 @@ findCollectionSelectors
 addMessageNode: aNode
 
 	allNodes add: aNode! !
+
+!COOP methodsFor: 'action' stamp: 'MEG 9/8/2019 14:20:26'!
+performInteractiveChecksFor: aMethodNode
+
+	rules do: [ :rule | rule check: aMethodNode ]! !
+
+
+!COOP methodsFor: 'initialization' stamp: 'MEG 9/8/2019 14:22:35'!
+initialize
+
+	rules _ Set new.! !

--- a/Parser-*Cuis-University-COOP.st
+++ b/Parser-*Cuis-University-COOP.st
@@ -1,0 +1,9 @@
+'From Cuis 5.0 [latest update: #3839] on 8 September 2019 at 2:25:26 pm'!
+
+
+!Parser methodsFor: '*Cuis-University-COOP' stamp: 'MEG 9/8/2019 14:04:27'!
+performCOOPChecksFor: aMethodNode
+
+	COOP new performInteractiveChecksFor: aMethodNode
+
+	! !

--- a/Parser-performInteractiveChecks.st
+++ b/Parser-performInteractiveChecks.st
@@ -1,0 +1,10 @@
+'From Cuis 5.0 [latest update: #3839] on 8 September 2019 at 7:28:59 pm'!
+
+!Parser methodsFor: '*Cuis-University-Model' stamp: 'MEG 9/8/2019 14:04:54'!
+performInteractiveChecks: aMethodNode
+
+	self
+		warnIfPossibilityOfSelfRecursion: aMethodNode;
+		declareUndeclaredTemps: aMethodNode;
+		performCOOPChecksFor: aMethodNode;
+		removeUnusedTemps! !


### PR DESCRIPTION
## Propósito

Queremos que COOP haga sus chequeos de reglas al momento de salvar un metodo.
Por ahora como no hay reglas el chequeo no tiene efecto.

## Información Adicional

Al momento de agregar una regla al Set de COOP, ya el parser va a estar realizando los chequeos.
Podemos redefinir `#parserClass` en **COOP Class** y evitar que esto ocurra, para poder realizar test y pruebas manuales mas tranquilos.