### PR TITLE
Desacoplar RefactoringTest

### DIFF
--- a/Cuis-University-COOP.pck.st
+++ b/Cuis-University-COOP.pck.st
@@ -1,22 +1,12 @@
-'From Cuis 5.0 [latest update: #3839] on 20 September 2019 at 7:14:27 pm'!
+'From Cuis 5.0 [latest update: #3839] on 22 September 2019 at 11:56:23 pm'!
 'Description '!
-!provides: 'Cuis-University-COOP' 1 1!
+!provides: 'Cuis-University-COOP' 1 2!
 SystemOrganization addCategory: #'Cuis-University-COOP'!
 SystemOrganization addCategory: #'Cuis-University-COOP-Tests'!
 
 
-!classDefinition: #COOPHelperTest category: #'Cuis-University-COOP-Tests'!
-RefactoringTest subclass: #COOPHelperTest
-	instanceVariableNames: 'coopHelper'
-	classVariableNames: ''
-	poolDictionaries: ''
-	category: 'Cuis-University-COOP-Tests'!
-!classDefinition: 'COOPHelperTest class' category: #'Cuis-University-COOP-Tests'!
-COOPHelperTest class
-	instanceVariableNames: ''!
-
 !classDefinition: #COOPMethodFactoryTest category: #'Cuis-University-COOP-Tests'!
-RefactoringTest subclass: #COOPMethodFactoryTest
+TestCase subclass: #COOPMethodFactoryTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
@@ -24,26 +14,6 @@ RefactoringTest subclass: #COOPMethodFactoryTest
 !classDefinition: 'COOPMethodFactoryTest class' category: #'Cuis-University-COOP-Tests'!
 COOPMethodFactoryTest class
 	instanceVariableNames: ''!
-
-!classDefinition: #COOPTest category: #'Cuis-University-COOP-Tests'!
-RefactoringTest subclass: #COOPTest
-	instanceVariableNames: 'coopHelper coop'
-	classVariableNames: ''
-	poolDictionaries: ''
-	category: 'Cuis-University-COOP-Tests'!
-!classDefinition: 'COOPTest class' category: #'Cuis-University-COOP-Tests'!
-COOPTest class
-	instanceVariableNames: ''!
-
-!classDefinition: #RuleCollectionSizeTest category: #'Cuis-University-COOP-Tests'!
-RefactoringTest subclass: #RuleCollectionSizeTest
-	instanceVariableNames: 'coopMethodFactory'
-	classVariableNames: ''
-	poolDictionaries: ''
-	category: 'Cuis-University-COOP-Tests'!
-!classDefinition: 'RuleCollectionSizeTest class' category: #'Cuis-University-COOP-Tests'!
-RuleCollectionSizeTest class
-	instanceVariableNames: 'coopHelper'!
 
 !classDefinition: #DemoTest category: #'Cuis-University-COOP-Tests'!
 TestCase subclass: #DemoTest
@@ -53,6 +23,26 @@ TestCase subclass: #DemoTest
 	category: 'Cuis-University-COOP-Tests'!
 !classDefinition: 'DemoTest class' category: #'Cuis-University-COOP-Tests'!
 DemoTest class
+	instanceVariableNames: ''!
+
+!classDefinition: #RuleCollectionSizeTest category: #'Cuis-University-COOP-Tests'!
+TestCase subclass: #RuleCollectionSizeTest
+	instanceVariableNames: 'methodFactory rule'
+	classVariableNames: ''
+	poolDictionaries: ''
+	category: 'Cuis-University-COOP-Tests'!
+!classDefinition: 'RuleCollectionSizeTest class' category: #'Cuis-University-COOP-Tests'!
+RuleCollectionSizeTest class
+	instanceVariableNames: 'coopHelper'!
+
+!classDefinition: #COOPMethodFactory category: #'Cuis-University-COOP-Tests'!
+LiveTypingTestFactory subclass: #COOPMethodFactory
+	instanceVariableNames: ''
+	classVariableNames: ''
+	poolDictionaries: ''
+	category: 'Cuis-University-COOP-Tests'!
+!classDefinition: 'COOPMethodFactory class' category: #'Cuis-University-COOP-Tests'!
+COOPMethodFactory class
 	instanceVariableNames: ''!
 
 !classDefinition: #COOP category: #'Cuis-University-COOP'!
@@ -65,26 +55,6 @@ Object subclass: #COOP
 COOP class
 	instanceVariableNames: ''!
 
-!classDefinition: #COOPHelper category: #'Cuis-University-COOP'!
-Object subclass: #COOPHelper
-	instanceVariableNames: ''
-	classVariableNames: ''
-	poolDictionaries: ''
-	category: 'Cuis-University-COOP'!
-!classDefinition: 'COOPHelper class' category: #'Cuis-University-COOP'!
-COOPHelper class
-	instanceVariableNames: ''!
-
-!classDefinition: #CollectionSendedMessageCheck category: #'Cuis-University-COOP'!
-Object subclass: #CollectionSendedMessageCheck
-	instanceVariableNames: 'statementNode selectors allNodes'
-	classVariableNames: ''
-	poolDictionaries: ''
-	category: 'Cuis-University-COOP'!
-!classDefinition: 'CollectionSendedMessageCheck class' category: #'Cuis-University-COOP'!
-CollectionSendedMessageCheck class
-	instanceVariableNames: ''!
-
 !classDefinition: #RuleCollectionSize category: #'Cuis-University-COOP'!
 Object subclass: #RuleCollectionSize
 	instanceVariableNames: ''
@@ -95,329 +65,52 @@ Object subclass: #RuleCollectionSize
 RuleCollectionSize class
 	instanceVariableNames: ''!
 
-!classDefinition: #COOPMethodFactory category: #'Cuis-University-COOP-Tests'!
-Object subclass: #COOPMethodFactory
-	instanceVariableNames: ''
-	classVariableNames: ''
-	poolDictionaries: ''
-	category: 'Cuis-University-COOP-Tests'!
-!classDefinition: 'COOPMethodFactory class' category: #'Cuis-University-COOP-Tests'!
-COOPMethodFactory class
-	instanceVariableNames: ''!
 
+!COOPMethodFactoryTest methodsFor: 'compiled-method-test' stamp: 'MEG 9/22/2019 23:49:16'!
+testCOOPMethodFactoryCompilesNewMethodNode
 
-!COOPHelperTest methodsFor: 'message' stamp: 'GET 9/8/2019 19:34:44'!
-testCOOPHelperSearchAMessageInAClass 
-	| aCompiledMethodExpected  aCompiledMethod | 
-	
-	coopHelper _ COOPHelper new. 
-	aCompiledMethodExpected _ (Collection methodsSelect: [:method | method selector == #size] ) at:1 .
-	
-	aCompiledMethod _ coopHelper search: #size in: Collection .
-	
-	self assert: aCompiledMethod  equals: aCompiledMethodExpected .! !
+	| methodFactory aMethodNode |
 
-!COOPHelperTest methodsFor: 'message' stamp: 'GET 9/8/2019 19:35:08'!
-testCOOPHelperSearchAMethodInAClassAndIsNotFoundThrowsAnError
-	|  selector  |
+	methodFactory _ COOPMethodFactory new.
 	
-	selector _ #iDontExist.
-	
-	self should: [coopHelper search: selector in: Collection] raise: Error - MessageNotUnderstood 
-		withMessageText: 'the message with ', selector , 'was not found in ', Collection className .! !
-
-!COOPHelperTest methodsFor: 'setup/teardown' stamp: 'GET 9/8/2019 19:34:20'!
-setUp 
-	super setUp.
-	coopHelper _ COOPHelper new.
-! !
-
-!COOPMethodFactoryTest methodsFor: 'compiled-method-test' stamp: 'GET 9/8/2019 19:33:37'!
-testCOOPHelperCompilesNewMethodNode
-	| aMethodNode aNewClass coopHelper |
-	aNewClass _ self createClassNamed: #TemporaryCoopHelper.
-	coopHelper _ COOPMethodFactory new.
-	aMethodNode _ coopHelper compileAndReturnIn: aNewClass aSelector: #temporal withSourceCode: '^ 1.'.
-	aNewClass removeFromSystem.
+	aMethodNode _ methodFactory compileAndReturnMethod: #temporal withSourceCode: '^ 1.'.
 	
 	self assert: aMethodNode class equals: MethodNode.
-	
-	self assert: aMethodNode selector equals: #temporal.
-	
-	self assert: aMethodNode block returns.! !
+	self assert: aMethodNode selector equals: #temporal.! !
 
-!COOPTest methodsFor: 'method-detection-test' stamp: 'GET 9/8/2019 19:37:29'!
-testCOOPDoesNotFindAMessageToACollectionAssigmentNode
-	| aClass aMethodNode |
-	
-	aClass _ self createClassNamed: #TemporalClass.
-	aMethodNode _ coopHelper compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' |var| var := Set new. ^ var'.
-	
-	self deny: (coop wasSendedToCollection: aMethodNode).! !
-
-!COOPTest methodsFor: 'method-detection-test' stamp: 'GET 9/8/2019 19:32:57'!
-testCOOPDoesNotFindAMessageToACollectionOnAMessageNode
-	| aClass aMethodNode |
-	
-	aClass _ self createClassNamed: #TemporalClass.
-	aMethodNode _ coopHelper compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' Set new'.
-	
-	self deny: (coop wasSendedToCollection: aMethodNode).! !
-
-!COOPTest methodsFor: 'method-detection-test' stamp: 'GET 9/8/2019 19:30:12'!
-testCOOPDoesNotFindAMessageToACollectionOnAReturnNode
-	| aClass aMethodNode |
-	aClass _ self createClassNamed: #TemporalClass.
-	aMethodNode _ coopHelper compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' ^ Set new'.
-	
-	self deny: (coop wasSendedToCollection: aMethodNode).! !
-
-!COOPTest methodsFor: 'method-detection-test' stamp: 'GET 9/8/2019 19:32:52'!
-testCOOPDoesNotFindAMessageToACollectionOnAReturnNodeWithArgs
-	| aClass aMethodNode |
-	
-	aClass _ self createClassNamed: #TemporalClass.
-	aMethodNode _ coopHelper compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' ^ true and: [false] '.
-	
-	self deny: (coop wasSendedToCollection: aMethodNode).! !
-
-!COOPTest methodsFor: 'method-detection-test' stamp: 'GET 9/8/2019 19:37:39'!
-testCOOPDoesNotFindAMessageToACollectionOnAnInstanceVariableNode
-	| aClass aMethodNode |
-	
-	aClass _ self createClassNamed: #TemporalClass.
-	aClass addInstanceVarNamed: 'number' withValue: 0. 
-	aMethodNode _ coopHelper compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' |var| var := number % 1  . ^ var'.
-	
-	self deny: (coop wasSendedToCollection: aMethodNode).! !
-
-!COOPTest methodsFor: 'method-detection-test' stamp: 'GET 9/8/2019 19:37:46'!
-testCOOPFindAMessageToACollectionOnAAssigmentNode
-	| aClass aMethodNode |
-
-	aClass _ self createClassNamed: #TemporalClass.
-	aMethodNode _ coopHelper compileAndReturnIn: aClass aSelector: #colaboration  withSourceCode: ' |var| var := Set new isEmpty. ^ var'.
-	
-	self assert: (coop wasSendedToCollection: aMethodNode).! !
-
-!COOPTest methodsFor: 'method-detection-test' stamp: 'GET 9/8/2019 19:32:40'!
-testCOOPFindAMessageToACollectionOnAMessageNode
-	| aClass aMethodNode |
-	
-	aClass _ self createClassNamed: #TemporalClass.
-	aMethodNode _ coopHelper compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' Set new isEmpty'.
-	
-	self assert: (coop wasSendedToCollection: aMethodNode).! !
-
-!COOPTest methodsFor: 'method-detection-test' stamp: 'GET 9/8/2019 19:32:37'!
-testCOOPFindAMessageToACollectionOnAReturnNode
-	| aClass aMethodNode |
-	
-	aClass _ self createClassNamed: #TemporalClass.
-	aMethodNode _ coopHelper  compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' ^ Set new isEmpty'.
-	
-	self assert: (coop wasSendedToCollection: aMethodNode).! !
-
-!COOPTest methodsFor: 'method-detection-test' stamp: 'GET 9/8/2019 19:32:31'!
-testCOOPFindAMessageToACollectionOnAReturnNodeWithArgs
-	| aClass aMethodNode |
-	
-	aClass _ self createClassNamed: #TemporalClass.
-	aMethodNode _ coopHelper compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' |newSet| newSet := Set new .  ^ 0 == newSet size'.
-	
-	self assert: (coop wasSendedToCollection: aMethodNode).! !
-
-!COOPTest methodsFor: 'method-detection-test' stamp: 'GET 9/8/2019 19:37:52'!
-testCOOPFindAMessageToACollectionOnAnInstanceVariableNode
-	| aClass aMethodNode |
-	
-	aClass _ self createClassNamed: #TemporalClass.
-	aClass addInstanceVarNamed: 'pepita' withValue: Set new. 
-	aMethodNode _ coopHelper compileAndReturnIn: aClass  aSelector: #colaboration withSourceCode: ' |var| var := pepita isEmpty. ^ var'.
-	
-	self assert: (coop wasSendedToCollection: aMethodNode).! !
-
-!COOPTest methodsFor: 'setup/teardown' stamp: 'GET 9/8/2019 19:29:11'!
-setUp
-	super setUp.
-	coopHelper _ COOPMethodFactory new.
-	coop _ COOP new.! !
-
-!RuleCollectionSizeTest methodsFor: 'rule-not-apply' stamp: 'MEG 9/11/2019 18:51:51'!
-testRuleCollectionSizeDoesNotApplyInAMethodNodeWithStandardCaseAsAComment
-
-	| aClass aMethodNode  collectionSizeRule |
-	collectionSizeRule _ RuleCollectionSize new.
-	aClass _ self createClassNamed: #TemporalClass.
-	
-	aMethodNode _ coopMethodFactory compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' "col size == 0" '.
-	
-	self deny: (collectionSizeRule check: aMethodNode) .! !
-
-!RuleCollectionSizeTest methodsFor: 'rule-not-apply' stamp: 'MEG 9/11/2019 18:51:48'!
-testRuleCollectionSizeDoesNotApplyInAMethodNodeWithStandardCaseUnordered
-
-	| aClass aMethodNode  collectionSizeRule |
-	collectionSizeRule _ RuleCollectionSize new.
-	aClass _ self createClassNamed: #TemporalClass.
-	
-	aMethodNode _ coopMethodFactory compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' col size. ^ 0 == 1. '.
-	
-	self deny: (collectionSizeRule check: aMethodNode) .! !
-
-!RuleCollectionSizeTest methodsFor: 'rule-not-apply' stamp: 'MEG 9/11/2019 18:51:45'!
-testRuleCollectionSizeDoesNotApplyWhenCaseIsNotThere
-
-	| aClass aMethodNode  collectionSizeRule |
-	collectionSizeRule _ RuleCollectionSize new.
-	aClass _ self createClassNamed: #TemporalClass.
-	
-	aMethodNode _ coopMethodFactory compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' ^ 0 == 1. '.
-	
-	self deny: (collectionSizeRule check: aMethodNode) .! !
-
-!RuleCollectionSizeTest methodsFor: 'rule-not-apply' stamp: 'MEG 9/11/2019 18:51:42'!
-testRuleCollectionSizeDoesNotApplyWhenSizeEqualsAndZeroAreNotInTheSameMessage
-
-	| aClass aMethodNode  collectionSizeRule |
-	collectionSizeRule _ RuleCollectionSize new.
-	aClass _ self createClassNamed: #TemporalClass.
-	
-	aMethodNode _ coopMethodFactory compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' 0 == 1 and col size == 1 '.
-	
-	self deny: (collectionSizeRule check: aMethodNode) .! !
-
-!RuleCollectionSizeTest methodsFor: 'rule-not-apply' stamp: 'MEG 9/11/2019 18:41:40'!
-testRuleCollectionSizeDoesNotApplyWhenTheMessageEndsOnSizeMethod
-
-	| aClass aMethodNode  collectionSizeRule |
-	collectionSizeRule _ RuleCollectionSize new.
-	aClass _ self createClassNamed: #TemporalClass.
-	
-	aMethodNode _ coopMethodFactory compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' ^ col size '.
-	
-	self deny: (collectionSizeRule check: aMethodNode) .! !
-
-!RuleCollectionSizeTest methodsFor: 'rule-not-apply' stamp: 'MEG 9/11/2019 18:51:08'!
-testRuleCollectionSizeDoesNotApplyWhenZeroIsOnInstanceVariableNode
-
-	| aClass aMethodNode  collectionSizeRule |
-	collectionSizeRule _ RuleCollectionSize new.
-	aClass _ self createClassNamed: #TemporalClass.
-	aClass addInstVarName: 'zero'.
-	
-	aMethodNode _ coopMethodFactory compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' ^ col size == zero '.
-	
-	self deny: (collectionSizeRule check: aMethodNode) .! !
-
-!RuleCollectionSizeTest methodsFor: 'rule-not-apply' stamp: 'MEG 9/11/2019 18:49:33'!
-testRuleCollectionSizeDoesNotApplyWhenZeroIsOnTemporaryVariableNode
-
-	| aClass aMethodNode  collectionSizeRule |
-	collectionSizeRule _ RuleCollectionSize new.
-	aClass _ self createClassNamed: #TemporalClass.
-	
-	aMethodNode _ coopMethodFactory compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' |zero| zero := 0. ^ col size == zero '.
-	
-	self deny: (collectionSizeRule check: aMethodNode) .! !
-
-!RuleCollectionSizeTest methodsFor: 'rule-apply' stamp: 'MEG 9/13/2019 18:11:49'!
-testRuleCollectionSizeApplyInAMethodNodeWithEqualMessageCase
-
-	| aClass aMethodNode  collectionSizeRule |
-	collectionSizeRule _ RuleCollectionSize new.
-	aClass _ self createClassNamed: #TemporalClass.
-	aMethodNode _ coopMethodFactory compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' col size = 0 '.
-	
-	self assert: (collectionSizeRule check: aMethodNode) .! !
-
-!RuleCollectionSizeTest methodsFor: 'rule-apply' stamp: 'MEG 9/11/2019 18:41:12'!
-testRuleCollectionSizeApplyInAMethodNodeWithInvertedCaseOfStandardRule
-
-	| aClass aMethodNode  collectionSizeRule |
-	collectionSizeRule _ RuleCollectionSize new.
-	aClass _ self createClassNamed: #TemporalClass.
-	aMethodNode _ coopMethodFactory compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' 0 == col size '.
-	
-	self assert: (collectionSizeRule check: aMethodNode) .! !
-
-!RuleCollectionSizeTest methodsFor: 'rule-apply' stamp: 'MEG 9/13/2019 18:19:24'!
-testRuleCollectionSizeApplyInAMethodNodeWithInvertedEqualMessageCase
-
-	| aClass aMethodNode  collectionSizeRule |
-	collectionSizeRule _ RuleCollectionSize new.
-	aClass _ self createClassNamed: #TemporalClass.
-	aMethodNode _ coopMethodFactory compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' 0 = col size '.
-	
-	self assert: (collectionSizeRule check: aMethodNode) .! !
-
-!RuleCollectionSizeTest methodsFor: 'rule-apply' stamp: 'MEG 9/11/2019 18:41:12'!
-testRuleCollectionSizeApplyInAMethodNodeWithStandardCase
-
-	| aClass aMethodNode  collectionSizeRule |
-	collectionSizeRule _ RuleCollectionSize new.
-	aClass _ self createClassNamed: #TemporalClass.
-	aMethodNode _ coopMethodFactory compileAndReturnIn: aClass aSelector: #colaboration withSourceCode: ' col size == 0 '.
-	
-	self assert: (collectionSizeRule check: aMethodNode) .! !
-
-!RuleCollectionSizeTest methodsFor: 'rule-apply' stamp: 'MEG 9/13/2019 18:27:00'!
-testRuleCollectionSizeApplyInAMethodNodeWithStandardCaseButAfterAReferenceNode
-
-	| aClass aMethodNode  collectionSizeRule |
-	collectionSizeRule _ RuleCollectionSize new.
-	aClass _ self createClassNamed: #TemporalClass.
-	aMethodNode _ coopMethodFactory compileAndReturnIn: aClass aSelector: #colaboration 
-		withSourceCode: ' |collectionSize| collectionSize := col size.  ^ col size == 0 '.
-	
-	self assert: (collectionSizeRule check: aMethodNode) .! !
-
-!RuleCollectionSizeTest methodsFor: 'setup/teardown' stamp: 'MEG 9/11/2019 18:37:03'!
-setUp
-
-	super setUp.
-
-	coopMethodFactory _ COOPMethodFactory new.! !
-
-!DemoTest methodsFor: 'apply' stamp: 'MEG 9/13/2019 19:29:12'!
+!DemoTest methodsFor: 'apply' stamp: 'MEG 9/22/2019 23:52:06'!
 testCollectionSizeIsEqualToZeroOpensAPopUpOnAccept
 
 	| collection |
 	collection _ OrderedCollection new.
 	
-	self assert: collection size = 0.
-	! !
+	self assert: collection size = 0.! !
 
-!DemoTest methodsFor: 'apply' stamp: 'MEG 9/13/2019 19:36:31'!
+!DemoTest methodsFor: 'apply' stamp: 'MEG 9/22/2019 23:52:12'!
 testCollectionSizeIsIdenticalToZeroOpensAPopUpOnAccept
 
 	| collection |
 	collection _ OrderedCollection new.
 	
-	self assert: collection size == 0.
-	
-	! !
+	self assert: collection size == 0.! !
 
-!DemoTest methodsFor: 'apply' stamp: 'MEG 9/13/2019 19:23:10'!
+!DemoTest methodsFor: 'apply' stamp: 'MEG 9/22/2019 23:52:17'!
 testZeroIsEqualToCollectionSizeOpensAPopUpOnAccept
 
 	| collection |
 	collection _ OrderedCollection new.
 	
-	self assert: 0 = collection size.
-	! !
+	self assert: 0 = collection size.! !
 
-!DemoTest methodsFor: 'apply' stamp: 'MEG 9/13/2019 19:34:04'!
+!DemoTest methodsFor: 'apply' stamp: 'MEG 9/22/2019 23:52:23'!
 testZeroIsIdenticalToCollectionSizeOpensAPopUpOnAccept
 
 	| collection |
 	collection _ OrderedCollection new.
 	
-	self assert: 0 == collection size.
-	
-	! !
+	self assert: 0 == collection size.! !
 
-!DemoTest methodsFor: 'not-apply' stamp: 'MEG 9/13/2019 19:27:41'!
+!DemoTest methodsFor: 'not-apply' stamp: 'MEG 9/22/2019 23:52:28'!
 testCollectionIsEmptyDoesNotOpenAPopUp
 
 	| collection |
@@ -425,17 +118,139 @@ testCollectionIsEmptyDoesNotOpenAPopUp
 	
 	self assert: collection isEmpty.! !
 
-!COOP methodsFor: 'testing' stamp: 'GET 9/8/2019 15:03:11'!
-searchMessageToCollectionsOn: aStatement
+!RuleCollectionSizeTest methodsFor: 'rule-not-apply' stamp: 'MEG 9/22/2019 23:47:29'!
+testRuleCollectionSizeDoesNotApplyInAMethodNodeWithStandardCaseAsAComment
 
-	| collectionSendedMessageRule |
-	collectionSendedMessageRule _ CollectionSendedMessageCheck new with:aStatement.
-	^ collectionSendedMessageRule analyze.! !
+	| aMethodNode |
+	
+	aMethodNode _ methodFactory compileAndReturnMethod: #colaboration withSourceCode: ' "col size == 0" '.
+	
+	self deny: (rule check: aMethodNode)! !
 
-!COOP methodsFor: 'testing' stamp: 'GET 9/8/2019 12:18:16'!
-wasSendedToCollection: aMethodNode
+!RuleCollectionSizeTest methodsFor: 'rule-not-apply' stamp: 'MEG 9/22/2019 23:47:35'!
+testRuleCollectionSizeDoesNotApplyInAMethodNodeWithStandardCaseUnordered
 
-	^  aMethodNode body statements anySatisfy: [:statement | self searchMessageToCollectionsOn: statement ] ! !
+	| aMethodNode |
+	
+	aMethodNode _ methodFactory compileAndReturnMethod: #colaboration withSourceCode: ' col size. ^ 0 == 1. '.
+	
+	self deny: (rule check: aMethodNode)! !
+
+!RuleCollectionSizeTest methodsFor: 'rule-not-apply' stamp: 'MEG 9/22/2019 23:47:42'!
+testRuleCollectionSizeDoesNotApplyWhenCaseIsNotThere
+
+	| aMethodNode |
+
+	aMethodNode _ methodFactory compileAndReturnMethod: #colaboration withSourceCode: ' ^ 0 == 1. '.
+	
+	self deny: (rule check: aMethodNode)! !
+
+!RuleCollectionSizeTest methodsFor: 'rule-not-apply' stamp: 'MEG 9/22/2019 23:47:48'!
+testRuleCollectionSizeDoesNotApplyWhenSizeEqualsAndZeroAreNotInTheSameMessage
+
+	| aMethodNode |
+
+	aMethodNode _ methodFactory compileAndReturnMethod: #colaboration withSourceCode: ' 0 == 1 and col size == 1 '.
+	
+	self deny: (rule check: aMethodNode)! !
+
+!RuleCollectionSizeTest methodsFor: 'rule-not-apply' stamp: 'MEG 9/22/2019 23:47:52'!
+testRuleCollectionSizeDoesNotApplyWhenTheMessageEndsOnSizeMethod
+
+	| aMethodNode |
+
+	aMethodNode _ methodFactory compileAndReturnMethod: #colaboration withSourceCode: ' ^ col size '.
+	
+	self deny: (rule check: aMethodNode)! !
+
+!RuleCollectionSizeTest methodsFor: 'rule-not-apply' stamp: 'MEG 9/22/2019 23:47:57'!
+testRuleCollectionSizeDoesNotApplyWhenZeroIsOnTemporaryVariableNode
+
+	| aMethodNode |
+	
+	aMethodNode _ methodFactory compileAndReturnMethod: #colaboration withSourceCode: ' |zero| zero := 0. ^ col size == zero '.
+	
+	self deny: (rule check: aMethodNode)! !
+
+!RuleCollectionSizeTest methodsFor: 'rule-apply' stamp: 'MEG 9/22/2019 23:49:36'!
+testRuleCollectionSizeApplyInAMethodNodeWithEqualMessageCase
+
+	| aMethodNode |
+	
+	aMethodNode _ methodFactory compileAndReturnMethod: #colaboration withSourceCode: ' col size = 0 '.
+	
+	self assert: (rule check: aMethodNode)! !
+
+!RuleCollectionSizeTest methodsFor: 'rule-apply' stamp: 'MEG 9/22/2019 23:45:04'!
+testRuleCollectionSizeApplyInAMethodNodeWithInvertedCaseOfStandardRule
+
+	| aMethodNode |
+	
+	aMethodNode _ methodFactory compileAndReturnMethod: #colaboration withSourceCode: ' 0 == col size '.
+	
+	self assert: (rule check: aMethodNode)! !
+
+!RuleCollectionSizeTest methodsFor: 'rule-apply' stamp: 'MEG 9/22/2019 23:45:26'!
+testRuleCollectionSizeApplyInAMethodNodeWithInvertedEqualMessageCase
+
+	| aMethodNode |
+	
+	aMethodNode _ methodFactory compileAndReturnMethod: #colaboration withSourceCode: ' 0 = col size '.
+	
+	self assert: (rule check: aMethodNode)! !
+
+!RuleCollectionSizeTest methodsFor: 'rule-apply' stamp: 'MEG 9/22/2019 23:45:35'!
+testRuleCollectionSizeApplyInAMethodNodeWithStandardCase
+
+	| aMethodNode |
+	
+	aMethodNode _ methodFactory compileAndReturnMethod: #colaboration withSourceCode: ' col size == 0 '.
+	
+	self assert: (rule check: aMethodNode)! !
+
+!RuleCollectionSizeTest methodsFor: 'rule-apply' stamp: 'MEG 9/22/2019 23:45:46'!
+testRuleCollectionSizeApplyInAMethodNodeWithStandardCaseButAfterAReferenceNode
+
+	| aMethodNode  |
+	
+	aMethodNode _ methodFactory compileAndReturnMethod: #colaboration 
+		withSourceCode: ' |collectionSize| collectionSize := col size.  ^ col size == 0 '.
+	
+	self assert: (rule check: aMethodNode)! !
+
+!RuleCollectionSizeTest methodsFor: 'setup/teardown' stamp: 'MEG 9/22/2019 23:44:29'!
+setUp
+
+	methodFactory _ COOPMethodFactory new.
+	
+	rule _ RuleCollectionSize new.! !
+
+!COOPMethodFactory methodsFor: 'action' stamp: 'MEG 9/22/2019 23:01:12'!
+compileAndReturnMethod: selector withSourceCode: sourceCode 
+	
+	| aMethodNode classToBeRemoved |
+	classToBeRemoved _ self createClassToBeRemoved.
+	aMethodNode _ self compileAndReturnMethodIn: classToBeRemoved named: selector withSourceCode: sourceCode.
+	classToBeRemoved removeFromSystem.
+	
+	^ aMethodNode! !
+
+!COOPMethodFactory methodsFor: 'action' stamp: 'MEG 9/22/2019 23:30:06'!
+compileAndReturnMethodIn: aClass named: aSelectorName withSourceCode: aSourceCode
+	
+	aClass compile: aSelectorName, aSourceCode.
+	
+	^ (aClass methodDictionary at: aSelectorName) methodNode.! !
+
+!COOPMethodFactory methodsFor: 'class categories' stamp: 'MEG 9/22/2019 23:00:04'!
+categoryOfClassToBeRemoved
+	
+	^ 'Cuis-University-COOP-Tests'! !
+
+!COOPMethodFactory methodsFor: 'classes' stamp: 'MEG 9/22/2019 22:54:05'!
+nameOfClassToBeRemoved
+	
+	^ #COOPClassToBeRemoved! !
 
 !COOP methodsFor: 'action' stamp: 'MEG 9/13/2019 19:36:04'!
 opensPopUpFor: rule
@@ -455,57 +270,6 @@ initialize
 	rules _ Set new.
 	
 	rules add: RuleCollectionSize new.! !
-
-!COOPHelper methodsFor: 'error' stamp: 'GET 9/8/2019 12:50:43'!
-messageNotFound: aSelector in: aClass
-
-	self error: 'the message with ', aSelector , 'was not found in ', aClass className .
-	! !
-
-!COOPHelper methodsFor: 'action' stamp: 'GET 9/8/2019 12:50:55'!
-search: aSelectorName in: aClass
-
-	^ aClass compiledMethodAt: aSelectorName ifPresent: [:compiledMethod | ^ compiledMethod ] ifAbsent: [ self messageNotFound: aSelectorName in: aClass ].
- ! !
-
-!COOPHelper methodsFor: 'testing' stamp: 'GET 9/8/2019 18:59:15'!
-exist: selectors in: aClass
-
-	^ selectors notEmpty and: [ aClass methodDict keys includesAnyOf:  selectors ].	! !
-
-!CollectionSendedMessageCheck methodsFor: 'initialize' stamp: 'GET 9/8/2019 19:35:31'!
-initialize
-	selectors _ Set new.
-	allNodes _  Set new.
-! !
-
-!CollectionSendedMessageCheck methodsFor: 'initialize' stamp: 'GET 9/8/2019 13:04:31'!
-with: aStatement
-
-statementNode  _ aStatement .! !
-
-!CollectionSendedMessageCheck methodsFor: 'testing' stamp: 'GET 9/8/2019 19:39:48'!
-analyze
-	| parser |
-	parser _ ParseNodeEnumerator ofBlock: [:node | self addMessageNode: node].
-	statementNode accept: parser.
-
-	self findCollectionSelectors.
-
-	 ^ COOPHelper new exist: selectors in: Collection .! !
-
-!CollectionSendedMessageCheck methodsFor: 'accessing' stamp: 'GET 9/8/2019 19:39:59'!
-findCollectionSelectors
-
-	| messageParser |
-	messageParser _ ParseNodeEnumerator ofBlock: [:node | selectors add: node selector  key] select: [:node | node isMessageNode].
-	allNodes do: [:node | node accept: messageParser ].
-	! !
-
-!CollectionSendedMessageCheck methodsFor: 'action' stamp: 'GET 9/8/2019 18:29:12'!
-addMessageNode: aNode
-
-	allNodes add: aNode! !
 
 !RuleCollectionSize methodsFor: 'testing' stamp: 'GET 9/10/2019 22:34:46'!
 check: aMethodNode 
@@ -541,13 +305,6 @@ checkIfNodeHasRule: statementNode
 	^ ( involvedNodes anySatisfy: [:node | node key == #size] ) 
 	and: [ involvedNodes anySatisfy: [:node | (node key == #==) or: [node key == #=] ] ] 
 	and: [  involvedNodes anySatisfy: [:node  | node key == 0 ] ].! !
-
-!COOPMethodFactory methodsFor: 'action' stamp: 'GET 9/8/2019 19:34:09'!
-compileAndReturnIn: aClass aSelector: aSelectorName withSourceCode: aSourceCode
-	
-	aClass compile: aSelectorName , aSourceCode.
-	
-	^ (aClass methodDictionary at: aSelectorName) methodNode.! !
 
 !Parser methodsFor: '*Cuis-University-COOP' stamp: 'MEG 9/13/2019 18:53:03'!
 performCOOPChecksFor: aMethodNode


### PR DESCRIPTION
## Propósito

Para no quedar acoplados a RefactoringTest, decidimos utilizar TestCase y extender solo lo necesario para crear clases temporales donde instanciar nuestros metodos.

## Cambios

Todas las clases de test que antes eran subclase de **RefactoringTest** ahora son subclase de **TestCase**.
Ademas se modifico la **MethodFactory** para que se encargue de instanciar y remover clases temporales.
Se opto por remover las clases **COOPHelper** y **CollectionSendedMessageCheck** para no invertir tiempo de refactor en codigo muerto.